### PR TITLE
Transport layer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-scala_211: &scala_211
-  SCALA_VERSION: 2.11.12
-
 scala_212: &scala_212
   SCALA_VERSION: 2.12.8
 
@@ -91,13 +88,6 @@ jobs:
       - <<: *scala_212
       - <<: *jdk_8
 
-  test_211_jdk8:
-    <<: *test
-    <<: *machine_ubuntu
-    environment:
-      - <<: *scala_211
-      - <<: *jdk_8
-
   test_212_jdk8:
     <<: *test
     <<: *machine_ubuntu
@@ -105,26 +95,12 @@ jobs:
       - <<: *scala_212
       - <<: *jdk_8
 
-  test_211_jdk11:
-    <<: *test
-    <<: *machine_ubuntu
-    environment:
-      - <<: *scala_211
-      - <<: *jdk_11
-
   test_212_jdk11:
     <<: *test
     <<: *machine_ubuntu
     environment:
       - <<: *scala_212
       - <<: *jdk_11
-
-  release_211:
-    <<: *release
-    <<: *machine_ubuntu
-    environment:
-      - <<: *scala_211
-      - <<: *jdk_8
 
   release_212:
     <<: *release
@@ -141,19 +117,7 @@ workflows:
           filters:
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-      - test_211_jdk8:
-          requires:
-            - lint
-          filters:
-            tags:
-              only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
       - test_212_jdk8:
-          requires:
-            - lint
-          filters:
-            tags:
-              only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-      - test_211_jdk11:
           requires:
             - lint
           filters:
@@ -165,20 +129,8 @@ workflows:
           filters:
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-      - release_211:
-          context: Sonatype
-          requires:
-            - test_211_jdk8
-            - test_211_jdk11
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
       - release_212:
           context: Sonatype
-          requires:
-            - release_211
           filters:
             branches:
               ignore: /.*/

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val zioKeeper = project
     libraryDependencies ++= Seq(
       "dev.zio"    %% "zio"                  % "1.0.0-RC11-1",
       "dev.zio"    %% "zio-streams"          % "1.0.0-RC11-1",
+      "dev.zio"    %% "zio-nio"              % "0.1.1",
       "org.specs2" %% "specs2-core"          % "4.7.0" % Test,
       "org.specs2" %% "specs2-scalacheck"    % "4.7.0" % Test,
       "org.specs2" %% "specs2-matcher-extra" % "4.7.0" % Test

--- a/src/main/scala/zio/keeper/Cluster.scala
+++ b/src/main/scala/zio/keeper/Cluster.scala
@@ -1,31 +1,279 @@
 package zio.keeper
 
-import java.net.InetAddress
+import java.math.BigInteger
+import java.util.UUID
 
-import zio.{ IO, ZIO }
+import zio._
+import zio.console.putStrLn
+import zio.keeper.Cluster.InternalProtocol.{ ProvideIdentity, RequestIdentity }
+import zio.keeper.Error.{ HandshakeError, NodeUnknown, SendError, SerializationError }
+import zio.nio._
+import zio.nio.channels.{ AsynchronousServerSocketChannel, AsynchronousSocketChannel }
 import zio.stream.Stream
-import zio.keeper.Cluster._
 
 trait Cluster {
-  final def join: ZIO[Credentials with Discovery with Transport, Error, Unit] = ???
+  def nodes: UIO[List[NodeId]]
+
+  def send(data: Chunk[Byte], receipt: NodeId): IO[Error, Unit]
+
+  def broadcast(data: Chunk[Byte]): IO[Error, Unit]
+
+  def receive: Stream[Error, Message]
 }
 
 object Cluster {
+
+  sealed trait InternalProtocol {
+    def serialize: IO[SerializationError, Chunk[Byte]]
+  }
+
+  object InternalProtocol {
+
+    case object RequestIdentity extends InternalProtocol {
+      override def serialize: IO[SerializationError, Chunk[Byte]] = ZIO.succeed(Chunk(1))
+    }
+
+    final case class ProvideIdentity(node: NodeId) extends InternalProtocol {
+      override def serialize: IO[SerializationError, Chunk[Byte]] =
+        ZIO.succeed(Chunk(2.toByte) ++ Chunk.fromArray(node.value.toString.getBytes))
+    }
+
+    final case class NotifyJoin(addr: InetAddress, port: Int) extends InternalProtocol {
+      override def serialize: IO[SerializationError, Chunk[Byte]] =
+        ZIO.succeed(
+          Chunk(3.toByte) ++
+            Chunk.fromArray(addr.address) ++
+            Chunk.fromArray(BigInteger.valueOf(port.toLong).toByteArray)
+        )
+    }
+
+    def deserialize(bytes: Chunk[Byte]): ZIO[Any, Throwable, InternalProtocol] =
+      if (bytes.isEmpty) {
+        ZIO.fail(SerializationError("Fail to deserialize message"))
+      } else {
+        val messageByte = bytes.drop(1)
+        bytes.apply(0) match {
+          case 1 =>
+            ZIO.succeed(RequestIdentity)
+          case 2 =>
+            ZIO.effect(ProvideIdentity(NodeId(UUID.fromString(new String(messageByte.toArray)))))
+          case 3 =>
+            for {
+              a   <- InetAddress.byAddress(messageByte.take(4).toArray)
+              res <- ZIO.effect(new BigInteger(messageByte.drop(4).toArray).intValue())
+            } yield NotifyJoin(a, res)
+        }
+      }
+
+  }
+
+  private def connectToSeed(publicAddr: InetAddress, port: Int, me: NodeId, seed: SocketAddress) =
+    for {
+      channel <- ZIO.accessM[Transport](_.connect(seed))
+      //initial handshake
+      bytes       <- RequestIdentity.serialize
+      ss          <- serializeMessage(me, bytes, 1)
+      _           <- channel.write(ss)
+      headerBytes <- channel.read(24)
+      byteBuffer  = new zio.nio.ByteBuffer(java.nio.ByteBuffer.wrap(headerBytes.toArray))
+      l1          <- byteBuffer.getLong
+      l2          <- byteBuffer.getLong
+      _           <- byteBuffer.getInt
+      payloadSize <- byteBuffer.getInt
+      payloadByte <- channel.read(payloadSize) // this should somehow be ignored when we cannot handle message because we are not able to handle protocol or version
+      _           = NodeId(new java.util.UUID(l1, l2))
+      m           <- InternalProtocol.deserialize(payloadByte)
+      res <- m match {
+              case InternalProtocol.ProvideIdentity(nodeId) =>
+                for {
+                  payload <- InternalProtocol.NotifyJoin(publicAddr, port).serialize
+                  bytes   <- serializeMessage(me, payload, 1)
+                  _       <- channel.write(bytes)
+                } yield (nodeId, channel)
+              case _ => ZIO.fail(HandshakeError("handshake error"))
+            }
+    } yield res
+
+  private def listenForClusterMessages(
+    currentNode: NodeId,
+    messageQueue: zio.Queue[Message],
+    initialNodes: Ref[Map[NodeId, AsynchronousSocketChannel]]
+  ) = {
+    for {
+      message <- messageQueue.take
+      payload <- InternalProtocol.deserialize(message.payload)
+      _ <- payload match {
+            case InternalProtocol.NotifyJoin(inetSocketAddress, port) =>
+              for {
+                client <- ZIO
+                           .accessM[Transport with zio.console.Console] { transport =>
+                             (SocketAddress.inetSocketAddress(inetSocketAddress, port) >>=
+                               transport.connect) <*
+                               putStrLn(
+                                 "connected with node [" + message.sender.value + "] " + inetSocketAddress.hostname + ":" + port
+                               )
+                           }
+                           .orDie
+                _ <- initialNodes.update(_.updated(message.sender, client)) //TODO here we should propagate membership event
+              } yield ()
+            case RequestIdentity =>
+              for {
+                payload <- ProvideIdentity(currentNode).serialize
+                bytes   <- serializeMessage(currentNode, payload, 1)
+                _       <- message.replyTo.write(bytes)
+              } yield ()
+            case _ => ZIO.unit
+          }
+    } yield ()
+  }.forever.fork
+
+  private def connectToCluster(localHost: InetAddress, port: Int, me: NodeId) =
+    for {
+      nodes <- zio.Ref.make(Map.empty[NodeId, AsynchronousSocketChannel])
+      seeds <- ZIO.accessM[Discovery](_.discover)
+      _ <- ZIO.foreach(seeds) { ip =>
+            connectToSeed(localHost, port, me, ip)
+              .flatMap(newNode => nodes.update(_ + newNode))
+              .catchAll(ex => putStrLn("seed [" + ip + "] ignored because of: " + ex.getMessage)) //we log this
+          }
+      internalMessagesQueue <- zio.Queue.bounded[Message](1000)
+      _                     <- listenForClusterMessages(me, internalMessagesQueue, nodes)
+
+    } yield (nodes, internalMessagesQueue)
+
+  private val HeaderSize = 24
+
+  private def serializeMessage(nodeId: NodeId, payload: Chunk[Byte], messageType: Int): IO[Error, Chunk[Byte]] = {
+    for {
+      byteBuffer <- Buffer.byte(HeaderSize + payload.length)
+      _          <- byteBuffer.putLong(nodeId.value.getMostSignificantBits)
+      _          <- byteBuffer.putLong(nodeId.value.getLeastSignificantBits)
+      _          <- byteBuffer.putInt(messageType)
+      _          <- byteBuffer.putInt(payload.length)
+      _          <- byteBuffer.putChunk(payload)
+      _          <- byteBuffer.flip
+      bytes      <- byteBuffer.getChunk()
+    } yield bytes
+  }.catchAll(ex => ZIO.fail(SerializationError(ex.getMessage)))
+
+  def join[A](
+    port: Int
+  ): ZIO[Credentials with Discovery with Transport with zio.console.Console, Error, Cluster] =
+    for {
+      localHost <- InetAddress.localHost.orDie
+      socketAddress <- SocketAddress
+                        .inetSocketAddress(localHost, port)
+                        .orDie // this should configurable especially for docker port forwarding this might be important
+      transport                     <- ZIO.environment[Transport]
+      server                        <- transport.bind(socketAddress).orDie
+      _                             <- putStrLn("Listening on " + localHost.hostname + ": " + port)
+      currentNodeId                 = NodeId(UUID.randomUUID())
+      nodesAndInternalMessagesQueue <- connectToCluster(localHost, port, currentNodeId)
+      userMessagesQueue             <- zio.Queue.bounded[Message](1000)
+
+      _ <- server.accept
+            .flatMap { channel =>
+              {
+                for {
+                  headerBytes            <- channel.read(HeaderSize)
+                  byteBuffer             <- Buffer.byte(headerBytes).map(_.asInstanceOf[ByteBuffer])
+                  senderMostSignificant  <- byteBuffer.getLong
+                  senderLeastSignificant <- byteBuffer.getLong
+                  messageType            <- byteBuffer.getInt
+                  payloadSize            <- byteBuffer.getInt
+                  payloadByte            <- channel.read(payloadSize)
+                  sender                 = NodeId(new java.util.UUID(senderMostSignificant, senderLeastSignificant))
+                  message                = Message(sender, payloadByte, channel)
+                  _ <- if (messageType == 1) {
+                        nodesAndInternalMessagesQueue._2.offer(message).unit
+                      } else if (messageType == 2) {
+                        userMessagesQueue.offer(message).unit
+                      } else {
+                        //this should be dead letter
+                        putStrLn("unsupported message type")
+                      }
+                } yield ()
+              }.whenM(channel.isOpen)
+                .forever
+                .ensuring(channel.close.ignore *> putStrLn("channel closed"))
+                .catchAll(ex => putStrLn("channel close because of: " + ex.getMessage)) //we log this
+                .fork                                                                   //this is individual channel for established connection
+            }
+            .orDie
+            .forever
+            .fork //this is waiting for new connections
+      _ <- putStrLn("Node [" + currentNodeId.value + "] started.")
+    } yield make(
+      currentNodeId,
+      userMessagesQueue,
+      nodesAndInternalMessagesQueue._1
+    )
+
+  private def make(
+    me: NodeId,
+    q: zio.Queue[Message],
+    initialNodes: Ref[Map[NodeId, AsynchronousSocketChannel]]
+  ) = new Cluster {
+    override def nodes =
+      initialNodes.get
+        .map(_.keys.toList) // should get from initial handshake( going through discovery list and try to connect) then gossip maintain this list
+
+    override def send(data: Chunk[Byte], receipt: NodeId): IO[Error, Unit] =
+      for {
+        nodes          <- initialNodes.get
+        receiptChannel <- ZIO.fromEither(nodes.get(receipt).toRight(NodeUnknown(receipt)))
+        payload        <- serializeMessage(me, data, 2)
+        _ <- receiptChannel
+              .write(payload)
+              .catchAll(ex => ZIO.fail(SendError(receipt, data, ex.getMessage)))
+      } yield ()
+
+    override def broadcast(data: Chunk[Byte]): IO[Error, Unit] =
+      for {
+        nodes   <- initialNodes.get
+        payload <- serializeMessage(me, data, 2).orDie
+        _ <- ZIO.traversePar_(nodes) {
+              case (receipt, channel) =>
+                channel
+                  .write(payload)
+                  .catchAll(ex => ZIO.fail(SendError(receipt, data, ex.getMessage)))
+            }
+      } yield ()
+
+    override def receive: Stream[Error, Message] =
+      zio.stream.Stream.fromQueue(q)
+  }
 
   trait Credentials {
     // TODO: ways to obtain auth data
   }
 
   trait Discovery {
-    def discover: IO[Error, Set[InetAddress]]
-  }
-
-  trait Gossip {
-    // TODO: gossipping interface
+    def discover: IO[Error, Set[zio.nio.SocketAddress]]
   }
 
   trait Transport {
-    def send[S, A](data: Message[S, A]): IO[Error, Unit]
-    def receive[S, A]: Stream[Error, Message[S, A]]
+    def bind(publicAddress: InetSocketAddress): Task[AsynchronousServerSocketChannel]
+
+    def connect(ip: SocketAddress): Task[AsynchronousSocketChannel]
   }
+
+  object Transport {
+
+    trait TCPTransport extends Transport {
+      override def bind(publicAddress: InetSocketAddress): Task[AsynchronousServerSocketChannel] =
+        for {
+          socket <- AsynchronousServerSocketChannel().orDie
+          _      <- socket.bind(publicAddress).orDie
+        } yield socket
+
+      override def connect(ip: SocketAddress): Task[AsynchronousSocketChannel] =
+        for {
+          client <- AsynchronousSocketChannel()
+          _      <- client.connect(ip)
+        } yield client
+    }
+
+  }
+
 }

--- a/src/main/scala/zio/keeper/Error.scala
+++ b/src/main/scala/zio/keeper/Error.scala
@@ -1,7 +1,16 @@
 package zio.keeper
 
-sealed trait Error
+sealed trait Error extends Exception
 
 object Error {
+
+  case class CannotFindSerializerForMessage[A](obj: A)    extends Error
+  case class CannotFindSerializerForMessageId(msgId: Int) extends Error
+
+  case class SerializationError(msg: String) extends Error
+
+  case class NodeUnknown(nodeId: NodeId)                             extends Error
+  case class SendError[A](nodeId: NodeId, message: A, error: String) extends Error
+  case class HandshakeError(msg: String)                             extends Error
   // TODO: define error hierarchy
 }

--- a/src/main/scala/zio/keeper/Message.scala
+++ b/src/main/scala/zio/keeper/Message.scala
@@ -1,3 +1,6 @@
 package zio.keeper
 
-final case class Message[S, A](sender: NodeId, state: S, payload: A)
+import zio.Chunk
+import zio.nio.channels.AsynchronousSocketChannel
+
+final case class Message(sender: NodeId, payload: Chunk[Byte], replyTo: AsynchronousSocketChannel)

--- a/src/main/scala/zio/keeper/NodeId.scala
+++ b/src/main/scala/zio/keeper/NodeId.scala
@@ -1,3 +1,5 @@
 package zio.keeper
 
-final case class NodeId(value: String) extends AnyVal
+import java.util.UUID
+
+final case class NodeId(value: UUID) extends AnyVal

--- a/src/main/scala/zio/keeper/package.scala
+++ b/src/main/scala/zio/keeper/package.scala
@@ -1,5 +1,0 @@
-package zio
-
-package object keeper {
-  val cluster = new Cluster {}
-}


### PR DESCRIPTION
Example of usage

```
package zio.keeper

import zio.{ Chunk, IO }
import zio.keeper.Cluster.{ Credentials, Discovery }
import zio.keeper.Cluster.Transport.TCPTransport
import zio.nio.{ InetAddress, SocketAddress }
import zio.console._

object Node1 extends zio.App {

  def run(args: List[String]) =
    appLogic.fold(_ => 1, _ => 0)

  val config = new Credentials with TCPTransport with Discovery with zio.console.Console.Live {

    override def discover: IO[Error, Set[SocketAddress]] =
      InetAddress.localHost
        .flatMap(addr => SocketAddress.inetSocketAddress(addr, 5558))
        .map(Set(_: SocketAddress))
        .orDie
  }

  val appLogic = Cluster
    .join(5557)
    .provide(config)
    .flatMap(c => c.broadcast(Chunk.fromArray("foo".getBytes)).map(_ => c))
    .flatMap(
      c => c.receive.foreach(n => putStrLn(new String(n.payload.toArray)) *> c.send(n.payload, n.sender))
    )
}

object Node2 extends zio.App {

  def run(args: List[String]) =
    appLogic.fold(_ => 1, _ => 0)

  val config = new Credentials with TCPTransport with Discovery with zio.console.Console.Live {

    override def discover: IO[Error, Set[SocketAddress]] =
      InetAddress.localHost
        .flatMap(addr => SocketAddress.inetSocketAddress(addr, 5557))
        .map(Set(_: SocketAddress))
        .orDie
  }

  val appLogic = Cluster
    .join(5558)
    .provide(config)
    .flatMap(c => c.broadcast(Chunk.fromArray("bar".getBytes)).map(_ => c))
    .flatMap(
      c => c.receive.foreach(n => putStrLn(new String(n.payload.toArray)) *> c.send(n.payload, n.sender))
    )

}
```