### PR TITLE
initial connection handshake improvements

### DIFF
--- a/src/main/scala/zio/keeper/Error.scala
+++ b/src/main/scala/zio/keeper/Error.scala
@@ -1,8 +1,13 @@
 package zio.keeper
 
+import zio.nio.SocketAddress
+
 sealed trait Error extends Exception
 
 object Error {
+
+  case class ConnectionTimeout(addr: SocketAddress) extends Error
+  case class RequestTimeout(addr: SocketAddress)    extends Error
 
   case class CannotFindSerializerForMessage[A](obj: A)    extends Error
   case class CannotFindSerializerForMessageId(msgId: Int) extends Error


### PR DESCRIPTION
this PR change the order of actions during initial connection to cluster. 

Most importantly node will not start listening on the the port if it's not in the cluster. 

Secondly we need to wait for confirmation of joining to the cluster from other nodes because we may broadcast message to nodes that don't have you on the list of nodes yet.