### PR TITLE
Update zio-sbt-website Plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,6 @@ addSbtPlugin("com.geirsson"     % "sbt-ci-release"            % "1.5.5")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"              % "2.4.2")
 addSbtPlugin("org.scalameta"    % "sbt-mdoc"                  % "2.2.14")
-addSbtPlugin("dev.zio"          % "zio-sbt-website"           % "0.0.0+84-6fd7d64e-SNAPSHOT")
+addSbtPlugin("dev.zio"          % "zio-sbt-website"           % "0.2.4")
 
 resolvers += Resolver.sonatypeRepo("public")


### PR DESCRIPTION
This update fixes the endless loop when the library has not been released yet.